### PR TITLE
Add selectable difficulty levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,11 @@
             margin-bottom: 20px;
             color: #ffff00;
         }
+
+        .difficulty {
+            font-size: 18px;
+            margin-bottom: 10px;
+        }
         
         .controls {
             margin-top: 20px;
@@ -77,6 +82,17 @@
         .game-over h2 {
             color: #ff0000;
             margin-bottom: 20px;
+        }
+
+        .start-screen {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: rgba(0, 0, 0, 0.9);
+            padding: 30px;
+            border-radius: 10px;
+            text-align: center;
         }
         
         button {
@@ -115,6 +131,7 @@
         <div class="info-panel">
             <div class="score">スコア: <span id="score">0</span></div>
             <div class="level">レベル: <span id="level">1</span></div>
+            <div class="difficulty">難易度: <span id="difficultyText">初級</span></div>
             
             <div class="next-piece">
                 <h3>次のピース</h3>
@@ -136,6 +153,13 @@
         <h2>ゲームオーバー</h2>
         <div class="score">最終スコア: <span id="finalScore">0</span></div>
         <button onclick="resetGame()">もう一度プレイ</button>
+    </div>
+
+    <div class="start-screen" id="startScreen">
+        <h2>難易度を選択</h2>
+        <button onclick="startGame('easy')">初級</button>
+        <button onclick="startGame('medium')">中級</button>
+        <button onclick="startGame('hard')">上級</button>
     </div>
 
     <script>
@@ -199,8 +223,20 @@
         let level = 1;
         let dropInterval = 1000;
         let lastDrop = 0;
-        let gameRunning = true;
+        let selectedDifficulty = 'easy';
+        let gameRunning = false;
         let isPaused = false;
+
+        function getDropInterval(diff) {
+            switch (diff) {
+                case 'hard':
+                    return 400;
+                case 'medium':
+                    return 700;
+                default:
+                    return 1000;
+            }
+        }
         
         // ボード初期化
         function initBoard() {
@@ -481,6 +517,11 @@
         function updateLevel() {
             document.getElementById('level').textContent = level;
         }
+
+        function updateDifficulty() {
+            const labels = { easy: '初級', medium: '中級', hard: '上級' };
+            document.getElementById('difficultyText').textContent = labels[selectedDifficulty];
+        }
         
         // ゲームオーバー
         function gameOver() {
@@ -493,25 +534,31 @@
         function resetGame() {
             score = 0;
             level = 1;
-            dropInterval = 1000;
+            dropInterval = getDropInterval(selectedDifficulty);
             gameRunning = true;
             isPaused = false;
             currentPiece = null;
             nextPiece = null;
-            
+
             updateScore();
             updateLevel();
+            updateDifficulty();
             initBoard();
             newPiece();
-            
+
             document.getElementById('gameOver').style.display = 'none';
             requestAnimationFrame(gameLoop);
         }
+
+        function startGame(diff) {
+            selectedDifficulty = diff;
+            document.getElementById('startScreen').style.display = 'none';
+            resetGame();
+        }
         
-        // ゲーム開始
+        // 初期表示
         initBoard();
-        newPiece();
-        requestAnimationFrame(gameLoop);
+        draw();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add difficulty and start screen styles
- display current difficulty
- provide start screen to choose Beginner/Intermediate/Advanced
- keep chosen difficulty when restarting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684aa20d4c4c8330a6effc6ae6d2df7f